### PR TITLE
Replace phoenix.router with plug.router

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,6 @@ defmodule Cldr.Mixfile do
       {:gettext, "~> 0.13", optional: true},
       {:stream_data, "~> 0.4", only: :test},
       {:dialyxir, "~> 0.5", only: :dev, runtime: false},
-      {:phoenix, "~> 1.3", optional: true, only: :test},
       {:plug, "~> 1.4", optional: true},
       {:sweet_xml, "~> 0.6", optional: true},
       {:benchee, "~> 0.13", only: :dev, runtime: false},

--- a/test/plug/plug_router_test.exs
+++ b/test/plug/plug_router_test.exs
@@ -1,28 +1,16 @@
 defmodule Cldr.TestApp.Router do
-  use Phoenix.Router
+  use Plug.Router
 
-  pipeline :locale_pipeline do
-    plug(Cldr.Plug.SetLocale, from: :path, cldr_backend: TestBackend.Cldr)
+  plug(:match)
+  plug(Cldr.Plug.SetLocale, from: :path, cldr_backend: TestBackend.Cldr)
+  plug(:dispatch)
+
+  get "/thing/:locale" do
+    send_resp(conn, 200, "")
   end
 
-  scope "/thing" do
-    pipe_through(:locale_pipeline)
-    get("/:locale", Cldr.PageController, :show)
-  end
-
-  scope "/thing/:locale" do
-    pipe_through(:locale_pipeline)
-    get("/other", Cldr.PageController, :show)
-  end
-end
-
-defmodule Cldr.PageController do
-  def init(_) do
-
-  end
-
-  def call(conn, _) do
-    conn
+  get "/thing/:locale/other" do
+    send_resp(conn, 200, "")
   end
 end
 


### PR DESCRIPTION
Didn't even need to remove the router in the end. Just used the plug one to remove the need for phoenix.
https://github.com/kipcole9/cldr/issues/84