### PR TITLE
Fix typespec and don't log warning if no matching locale was found

### DIFF
--- a/lib/cldr/accept_language.ex
+++ b/lib/cldr/accept_language.ex
@@ -391,7 +391,8 @@ defmodule Cldr.AcceptLanguage do
 
   """
   @spec best_match(String.t(), Cldr.backend()) ::
-          {:ok, LanguageTag.t()} | {:error, {Cldr.AcceptLanguageError, String.t()}}
+          {:ok, LanguageTag.t()}
+          | {:error, {Cldr.AcceptLanguageError | Cldr.NoMatchingLocale, String.t()}}
 
   def best_match(accept_language, backend) when is_binary(accept_language) do
     with {:ok, languages} <- parse(accept_language, backend) do

--- a/lib/cldr/plug/plug_accept_language.ex
+++ b/lib/cldr/plug/plug_accept_language.ex
@@ -63,6 +63,9 @@ if Code.ensure_loaded?(Plug) do
         {:ok, locale} ->
           locale
 
+        {:error, {Cldr.NoMatchingLocale, _reason}} ->
+          nil
+
         {:error, {exception, reason}} ->
           Logger.warn("#{exception}: #{reason}")
           nil

--- a/lib/cldr/plug/plug_set_session.ex
+++ b/lib/cldr/plug/plug_set_session.ex
@@ -24,7 +24,7 @@ if Code.ensure_loaded?(Plug) do
         	    from: [:path, :query],
         	    gettext: MyApp.Gettext,
         	    cldr: MyApp.Cldr
-            plug :Cldr.Plug.SetSession
+            plug Cldr.Plug.SetSession
             plug :fetch_flash
             plug :protect_from_forgery
             plug :put_secure_browser_headers
@@ -44,10 +44,11 @@ if Code.ensure_loaded?(Plug) do
     @doc false
     def call(conn, _options) do
       case SetLocale.get_cldr_locale(conn) do
-        %{cldr_locale_name: cldr_locale} ->
+        %Cldr.LanguageTag{cldr_locale_name: cldr_locale} ->
           conn
           |> fetch_session()
           |> put_session(SetLocale.session_key(), cldr_locale)
+
         _other ->
           conn
       end


### PR DESCRIPTION
This MR …

- fixes the typespec of `Cldr.AcceptLanguage.best_match/2`
- fixes a typo in the documentation of  `Cldr.Plug.SetSession`
- and changes `Cldr.Plug.AcceptLanguage` to not log a warning if no matching locale was found

If the latter is not desired, I would suggest making the log level configurable so that the user of this library can decide whether errors are logged.