### PR TITLE
Also support telemetry v1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Cldr.Mixfile do
       {:plug, "~> 1.9", optional: true},
       {:sweet_xml, "~> 0.6", only: [:dev, :test], optional: true},
       {:benchee, "~> 1.0", only: :dev, runtime: false, optional: true},
-      {:telemetry, "~> 0.4.0", optional: true},
+      {:telemetry, "~> 0.4 or ~> 1.0", optional: true},
       {:ratio, "~> 2.0", only: [:dev, :test], optional: true}
     ]
   end


### PR DESCRIPTION
Right now I have to have `{:telemetry, "~> 1.0", override: true},` in my mix.exs file. There are no changes from `0.4.3` to `1.0.0` (https://github.com/beam-telemetry/telemetry/blob/04a1649098da2eee4856ff65ca456343fc6a0be6/CHANGELOG.md#100).