### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,25 +122,7 @@ Each of these packages includes `ex_cldr` as a dependency so configuring any of 
 
 `Cldr` attempts to maximise runtime performance at the expense of additional compile time.  Where possible `Cldr` will create functions to encapsulate data at compile time.  To perform these optimizations for all 541 locales known to Cldr wouldn't be an effective use of your time or your computer's.  Therefore `Cldr` requires that you configure the locales you want to use.
 
-The preferred way to configure `Cldr` is to define the configuration in your backend module. This removes any dependency on your `mix.exs` and therefore simplifies deployment as a release.  However configuration can also be defined in other ways:
-
-### Global configuration.
-
-In `config.exs` a global configuration can be defined under the `:ex_cldr` key.  Although any valid configuration keys can be used here, only the keys `:json_library`, `:default_locale`, `:default_backend`, `:cacertfile`, `:data_dir`, `:force_locale_download` are considered valid.  Other configuration keys may be used to aid migration from `Cldr` version 1.x but a deprecation message will be printed during compilation.  Here's an example of global configuration:
-
-```elixir
-config :ex_cldr,
-  default_locale: "en",
-  default_backend: MyApp.Cldr,
-  json_library: Jason,
-  cacertfile: "path/to/cacertfile"
-```
-
-Note that the `:json_library` key can only be defined at the global level since it is required during compilation before any backend module is compiled.
-
-On most platforms other than Windows the `:cacertfile` will be automatically detected. Any configured `:cacertfile` will take precedence on all platforms.
-
-**If configuration beyond the keys `:default_locale`, `:cacertfile` or `:json_library` are defined a deprecation warning is printed at compile time noting that configuration should be moved to a backend module.**
+The preferred way to configure `Cldr` is to define the configuration in your backend module. This removes any dependency on your `mix.exs` and therefore simplifies deployment as a release.
 
 ### Backend Module Configuration
 
@@ -185,6 +167,24 @@ config :my_app, MyApp.Cldr,
 ```
 
 Multiple backends can be configured under a single `:otp_app` if required.
+
+### Global configuration.
+
+In `config.exs` a global configuration can be defined under the `:ex_cldr` key.  Although any valid configuration keys can be used here, only the keys `:json_library`, `:default_locale`, `:default_backend`, `:cacertfile`, `:data_dir`, `:force_locale_download` are considered valid.  Other configuration keys may be used to aid migration from `Cldr` version 1.x but a deprecation message will be printed during compilation.  Here's an example of global configuration:
+
+```elixir
+config :ex_cldr,
+  default_locale: "en",
+  default_backend: MyApp.Cldr,
+  json_library: Jason,
+  cacertfile: "path/to/cacertfile"
+```
+
+Note that the `:json_library` key can only be defined at the global level since it is required during compilation before any backend module is compiled.
+
+On most platforms other than Windows the `:cacertfile` will be automatically detected. Any configured `:cacertfile` will take precedence on all platforms.
+
+**If configuration beyond the keys `:default_locale`, `:cacertfile` or `:json_library` are defined a deprecation warning is printed at compile time noting that configuration should be moved to a backend module.**
 
 ### Configuration Priority
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ end
 The first step is to define a module that will host the desired `ex_cldr` configuration and the functions that serve as the public API.  This module is referred to in this documentation as a `backend` module. For example:
 
 ```elixir
-@doc """
-Define a backend module that will host our
-Cldr configuration and public API.
-
-Most function calls in Cldr will be calls
-to functions on this module.
-"""
 defmodule MyApp.Cldr do
+  @moduledoc """
+  Define a backend module that will host our
+  Cldr configuration and public API.
+
+  Most function calls in Cldr will be calls
+  to functions on this module.
+  """
   use Cldr,
     locales: ["en", "fr", "zh", "th"],
     default_locale: "en"

--- a/README.md
+++ b/README.md
@@ -147,22 +147,34 @@ end
 
 ### Otp App Configuration
 
-In the backend configuration example above the `:otp_app` key has been defined.  This means that configuration for `Cldr` has been defined in `mix.exs` under the key `:my_app` with the sub-key `MyApp.Cldr`.  For example:
+In the backend configuration example above the `:otp_app` key has been defined.  This means that `Cldr` will look for additional configuration, defined under the key `:my_app` with the sub-key `MyApp.Cldr`.  For example:
 
 ```elixir
+# cldr.ex
 defmodule MyApp.Cldr do
-  use Cldr, otp_app: :my_app
+  use Cldr, 
+    otp_app: :my_app,
+    default_locale: "en",
+    gettext: MyApp.Gettext,
+    json_library: Jason,
+    data_dir: "./priv/cldr",
+    precompile_number_formats: ["¤¤#,##0.##"],
+    providers: [Cldr.Number]
 end
 ```
 
 ```elixir
-# In mix.exs
+# config/config.exs
 config :my_app, MyApp.Cldr,
-  default_locale: "en",
+  # a single locale, for fast compilation in dev / test
+  locales: ["en"]
+```
+
+```elixir
+# config/production.exs
+config :my_app, MyApp.Cldr,
+  # these will take a while to compile
   locales: ["fr", "en", "bs", "si", "ak", "th"],
-  gettext: MyApp.Gettext,
-  data_dir: "./priv/cldr",
-  precompile_number_formats: ["¤¤#,##0.##"],
   precompile_transliterations: [{:latn, :arab}, {:thai, :latn}]
 ```
 


### PR DESCRIPTION
I ran into a compilation error while setting up CLDR for a new project, so I updated the README.
It was caused by the docstring being defined outside of a module:

```
== Compilation error in file lib/janus_web/cldr.ex ==
** (ArgumentError) cannot invoke @/1 outside module
    (elixir 1.13.3) lib/kernel.ex:6111: Kernel.assert_module_scope/3
    (elixir 1.13.3) expanding macro: Kernel.@/1
    lib/janus_web/cldr.ex:1: (file)
```