### PR TITLE
Problem: dependent build fails behind an unauthenticated proxy

### DIFF
--- a/lib/cldr/install.ex
+++ b/lib/cldr/install.ex
@@ -101,6 +101,11 @@ defmodule Cldr.Install do
 
     url = "#{base_url()}#{locale_filename(locale_name)}"
 
+    if proxy = System.get_env("HTTPS_PROXY") || System.get_env("https_proxy") do
+      %{host: host, port: port} = URI.parse(proxy)
+      :httpc.set_options([{:https_proxy, {{String.to_charlist(host), port}, []}}])
+    end
+
     case Cldr.Http.get(url) do
       {:ok, body} ->
         output_file_name


### PR DESCRIPTION
## Problem

During a CI build behind a proxy (no auth parameters, just `HTTPS_PROXY` set, getting dependencies works, however building cldr fails with:

```log
[error] Timeout connecting to 'raw.githubusercontent.com' to download 'https://raw.githubusercontent.com/elixir-cldr/cldr/v2.37.0/priv/cldr/locales/de.json'. Connection time exceeded 60000ms.
Generating MyModule.Cldr for 3 locales named [:de, :en, :und] with a default locale named :en
== Compilation error in file lib/my_module/cldr.ex ==
** (RuntimeError) Locale definition was not found for :de
    (ex_cldr 2.37.0) lib/cldr/locale/loader.ex:109: Cldr.Locale.Loader.do_get_locale/2
    (ex_cldr 2.37.0) lib/cldr/config/config.ex:2315: Cldr.Config.decimal_formats_for/2
    (elixir 1.14.4) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
    (ex_cldr 2.37.0) lib/cldr/config/config.ex:2302: Cldr.Config.decimal_format_list/1
    (ex_cldr_numbers 2.31.0) lib/cldr/number/formatter/decimal_formatter.ex:935: Cldr.Number.Formatter.Decimal.define_to_string/1
    (ex_cldr_numbers 2.31.0) lib/cldr/number/backend/decimal_formatter.ex:52: Cldr.Number.Backend.Decimal.Formatter.define_number_module/1
    (ex_cldr_numbers 2.31.0) lib/cldr/number/backend/compiler.ex:11: Cldr.Number.Backend.define_number_modules/1
    (ex_cldr 2.37.0) lib/cldr/config/config.ex:2632: anonymous fn/3 in Cldr.Config.define_provider_modules/1
error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1
```

as [httpc options](https://github.com/elixir-cldr/cldr_utils/blob/master/lib/cldr/http/http.ex#L117) are not set in [`Cldr.Install.install_locale_name`](https://github.com/elixir-cldr/cldr/blob/master/lib/cldr/install.ex#L104)

## Solution

- Try setting a proxy during build
  - similar to [esbuild](https://github.com/phoenixframework/esbuild/blob/main/lib/esbuild.ex#L329) or [mix](https://github.com/elixir-lang/elixir/blob/ab302d23e4b632486645cdf0fcc392e66b7abb99/lib/mix/lib/mix/utils.ex#L631)
- If anyone needs further options for `httpc`, another mechanism might be preferable