### PR TITLE
Fix typespec for Cldr.with_locale: Allow strings for locale argument

### DIFF
--- a/lib/cldr.ex
+++ b/lib/cldr.ex
@@ -432,7 +432,7 @@ defmodule Cldr do
   """
   @doc since: "2.27.0"
 
-  @spec with_locale(Cldr.Locale.locale_name(), backend(), fun) :: any
+  @spec with_locale(Cldr.Locale.locale_name() | String.t(), backend(), fun) :: any
   def with_locale(locale, backend \\ default_backend!(), fun) when is_locale_name(locale) do
     with {:ok, locale} = validate_locale(locale, backend) do
       with_locale(locale, fun)


### PR DESCRIPTION
`Cldr.with_locale` allows passing strings for the locale, as already verified by one of the tests in `test/cldr_test.exs:319`

```ex
assert Cldr.with_locale("fr", TestBackend.Cldr, fn -> Cldr.get_locale(TestBackend.Cldr) end) == fr_locale
```

