### PR TITLE
Silence dialyzer warnings about do_plural_rule

### DIFF
--- a/lib/cldr/plural_rules/plural_rule.ex
+++ b/lib/cldr/plural_rules/plural_rule.ex
@@ -665,6 +665,11 @@ defmodule Cldr.Number.PluralRule do
   def define_plural_rules do
     quote bind_quoted: [], location: :keep do
       alias Cldr.Number.PluralRule
+      
+      # Silence warnings since the success typing of do_plural_rule will depend
+      # on the locale used.
+      @dialyzer {:nowarn_function, [do_plural_rule: 8]}
+
       # Generate the functions to process plural rules
       @spec do_plural_rule(
               LanguageTag.t(),


### PR DESCRIPTION
Libraries that depend on Cldr might use the `:extra_returns` feature in dialyzer, which will warn if the typespec of a function specifies return types that are not part of the success typing.

My understanding is that the behavior (and therefore success typing) of `do_plural_rule depends/8` on the locale used, so we cannot accurately tell what the correct return type is. Therefore, this commit posits to silence dialyzer warnings about `do_plural_rule/8`.

Fixes #219 